### PR TITLE
Add ERDDAP_BASE_IMAGE build arg allowing for config of ERDDAP version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM axiom/docker-erddap:2.24-jdk21-openjdk AS base
+ARG ERDDAP_BASE_IMAGE=erddap/erddap:v2.28.1
+FROM $ERDDAP_BASE_IMAGE AS base
 
 LABEL organization="ISP-CNR" \
       developers="Giulio Verazzo, Alice Cavaliere" \
@@ -18,9 +19,9 @@ RUN bash /datasets_xml_parts/compile_datasets_xml.sh
 
 FROM base AS dev
 
-  COPY my_entrypoint.sh /
-  RUN ["chmod", "+x", "/my_entrypoint.sh"]
-  ENTRYPOINT ["/my_entrypoint.sh"]
-  EXPOSE 8080 5000 5678
+COPY my_entrypoint.sh /
+RUN ["chmod", "+x", "/my_entrypoint.sh"]
+ENTRYPOINT ["/my_entrypoint.sh"]
+EXPOSE 8080 5000 5678
 
-  CMD ["catalina.sh", "run"]
+CMD ["catalina.sh", "run"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ The default credentials for the admin user in the CMS are:
 - username: `admin`
 - password: `admin`
 
+To specify a specific ERDDAP Docker base image, run `docker compose build`
+with an `ERDDAP_BASE_IMAGE` build-arg before starting the compose stack.
+
+```
+docker compose build --build-arg ERDDAP_BASE_IMAGE=erddap/erddap:v2.28.1
+docker compose up -d
+```
+
 ## Miscellaneous
 
 Datasets configuration files and data are not tracked by git.


### PR DESCRIPTION
Great project! This change allows users/developers to specify an ERDDAP base image during the build, and upgrades the default base image to `erddap/erddap:v2.28.1`.